### PR TITLE
Convert table-based calendar to responsive UL

### DIFF
--- a/assets/css/sc-events.css
+++ b/assets/css/sc-events.css
@@ -1,10 +1,4 @@
 #sc_events_calendar:after { display: block; float: none; clear: both; height: 0; content: "."; text-indent: -9999px; }
-#sc_calendar table { width: 100%; border-collapse: collapse; float:left; }
-#sc_calendar th { width: 13.25%; background: #fdfdfd; border: 1px solid #ddd; text-align: center; text-transform: capitalize; padding: 3px 4px!important; }
-#sc_calendar td { width: 13.25%; border: 1px solid #ddd; font-size: 11px; padding: 0!important; }
-#sc_calendar td.calendar-day { background: #fbfbfb; height: 40px; }
-#sc_calendar td.calendar-day-np { background: #f0f0f0; }
-#sc_calendar td div.sc_day_div { padding: 8px; }
 #sc_events_calendar_head { padding: 8px; height: 26px; background: #f0f0f0; border: 1px solid #ddd; border-bottom: none; }
 #sc_event_select, #sc_event_nav_wrap, #sc_events_calendar_head h2 { width: 33%; float: left; margin: 0; clear:none; }
 #sc_event_nav_wrap { text-align: right; }
@@ -13,9 +7,26 @@
 #sc_events_calendar select, #sc_events_calendar input { margin: 0 5px 0 0; }
 .sc_small #sc_event_nav_wrap { margin: 8px 0 0 0; }
 .sc_small #sc_event_nav_wrap, .sc_small #sc_event_select { float: none; width: 100%; }
-.sc_small #sc_calendar td div { padding: 1px; }
 .sc_small #sc_event_nav_prev, .sc_small #sc_event_nav_next { display: block; width: 50%; float: left; }
 .sc_small #sc_event_nav_prev { text-align: left; }
-#sc_calendar td div.day-number { float: right; margin: -6px -4px 0 0; }
-.sc_small #sc_calendar  td div.day-number { float: none; text-align: right; padding: 0; margin: -3px 1px 0 0; }
 .sc_event_details { margin: 0 0 15px; }
+/* responsive styles */
+#calendar{margin:15px 0;}
+#calendar ul{list-style:none;padding:0;margin:0;width:100%;}
+#calendar li{min-height:20px;display:block;float:left;padding:5px;box-sizing:border-box;border:1px solid #ccc;margin-right:-1px;margin-bottom:-1px;}
+.calendar-day-head, #calendar li.calendar-day-np{display:none;}
+ul.calendar-day-head {height:40px;background:#555;}
+#calendar ul.calendar-day-head li{text-align:center;line-height:20px;border:none;padding:10px 6px;color:#fff;font-size:13px;}
+#calendar .calendar-row li{width:100%;padding:10px;margin-bottom:-1px;}
+.day-number{text-align:center;margin-bottom:5px;padding:4px;background:#ddd;color:#444;width:25px;border-radius:50%;}
+#calendar .event {clear:both;display:block;font-size:13px;border-radius:4px;padding:5px;margin-bottom:5px;line-height:14px;background:#eef;border:1px solid #bbc;color:#009aaf;text-decoration:none;}
+#calendar .event:first{margin-top:40px;}
+.event-desc {color:#555;margin:3px 0 7px 0;text-decoration:none;}
+.sc_events_calendar:after{visibility:hidden;display:block;font-size:0;content:" ";clear:both;height:25px;}
+@media (min-width: 741px) {
+	.calendar-day-head{display:block;}
+	#calendar li.calendar-day-np{background:#ddd;display:block;}
+	.day-number{float:right;}
+	#calendar .calendar-row li{min-height:170px;width:14.342%;}
+	#calendar ul.calendar-day-head li{width:14.342%;}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,13 +4,14 @@
 * Build Calendar for Event post type
 *
 * Credits : http://davidwalsh.name/php-calendar
+*			https://responsivedesign.is/patterns/calendar
 *
 */
 
 function sc_draw_calendar( $month, $year ){
 
-	//start draw table
-	$calendar = '<table cellpadding="0" cellspacing="0" class="calendar">';
+	//begin calendar div
+	$calendar = "\n<div id=\"calendar\">\n";
 
 	$day_names = array(
 		0 => __('Sunday', 'pippin_sc'),
@@ -32,11 +33,11 @@ function sc_draw_calendar( $month, $year ){
 		$day_names[] = $end_day;
 	}
 
-	$calendar.= '<tr class="calendar-row">';
+	$calendar .= "\t\t\t\t<ul class=\"calendar-day-head\">\n";
 		for( $i = 0; $i <= 6; $i++ ) {
-			$calendar .= '<th class="calendar-day-head">' . $day_names[$i] .'</th>';
+			$calendar .= "\t\t\t\t\t<li>" . $day_names[$i] . "</li>\n";
 		}
-	$calendar .= '</tr>';
+	$calendar .= "\t\t\t\t</ul>\n";
 
 	//days and weeks vars now
 	$running_day = date( 'w', mktime( 0, 0, 0, $month, 1, $year ) );
@@ -54,12 +55,12 @@ function sc_draw_calendar( $month, $year ){
 	$today_year = date('Y', $time);
 
 	//row for week one */
-	$calendar.= '<tr class="calendar-row">';
+	$calendar .= "\t\t\t\t<ul class=\"calendar-row\">\n";
 
 	//print "blank" days until the first of the current week
 	for($x = 0; $x < $running_day; $x++):
 
-		$calendar.= '<td class="calendar-day-np" valign="top"></td>';
+		$calendar .= "\t\t\t\t\t<li class=\"calendar-day calendar-day-np\"></li>\n";
 		$days_in_this_week++;
 
 	endfor;
@@ -69,10 +70,10 @@ function sc_draw_calendar( $month, $year ){
 
 		$today = ( $today_day == $list_day && $today_month == $month && $today_year == $year ) ? 'today' : '';
 
-		$cal_day = '<td class="calendar-day '. $today .'" valign="top"><div class="sc_day_div">';
+		$cal_day = "\t\t\t\t\t<li class=\"calendar-day " . $today . $category_string . "\">\n";
 
 		// add in the day numbering
-		$cal_day .= '<div class="day-number">'.$list_day.'</div>';
+		$cal_day .= "\t\t\t\t\t\t<div class=\"day-number day-" . $list_day . '">'.$list_day."</div>\n";
 
 		$args = array(
 			'numberposts' => -1,
@@ -115,7 +116,7 @@ function sc_draw_calendar( $month, $year ){
 				$evt_month 	== $month &&
 				$evt_year 	== $year
 			) {
-				$cal_event .= '<a href="'. get_permalink($id) .'">'. get_the_title($id) .'</a><br/>';
+				$cal_event .= "\t\t\t\t\t\t<div class=\"event\" itemscope itemtype=\"http://schema.org/Event\"><meta itemprop=\"startDate\" content=\""; $epoch = get_post_meta($id, 'sc_event_date_time'); $link .= date('Y-m-d', $epoch[0]) . '"><div class="event-desc"><a itemprop="url" href="' . get_permalink($id) . '"><span itemprop="name">' . esc_html(get_the_title($id)) . "</span></a></div></div>\n";
 			}
 
 		endforeach;
@@ -124,14 +125,14 @@ function sc_draw_calendar( $month, $year ){
 
 		$calendar.= $cal_event ? $cal_event : '';
 
-		$calendar.= '</div></td>';
+		$calendar .= "\t\t\t\t\t</li>\n";
 
 		if($running_day == 6):
 
-			$calendar.= '</tr>';
+			$calendar .= "\t\t\t\t</ul>\n";
 
 			if( ( $day_counter + 1 ) != $days_in_month ):
-				$calendar .= '<tr class="calendar-row">';
+				$calendar .= "\t\t\t\t<ul class=\"calendar-row\">\n";
 			endif;
 
 			$running_day = -1;
@@ -146,19 +147,19 @@ function sc_draw_calendar( $month, $year ){
 	//finish the rest of the days in the week
 	if( $days_in_this_week < 8 ):
 		for( $x = 1; $x <= ( 8 - $days_in_this_week ); $x++ ):
-		  $calendar.= '<td class="calendar-day-np" valign="top"><div class="sc_day_div"></div></td>';
+		  $calendar .= "\t\t\t\t\t<li class=\"calendar-day calendar-day-np\"></li>\n";
 		endfor;
 	endif;
 
 	wp_reset_postdata();
 
 	//final row
-	$calendar.= '</tr>';
+	$calendar .= "\t\t\t\t</ul>\n";
 
-	//end the table
-	$calendar.= '</table>';
+	//close the div
+	$calendar .= '</div>';
 
-	//all done, return the completed table
+	//all done, return the completed calendar
 	return $calendar;
 }
 


### PR DESCRIPTION
- Replaced the table that wrapped calendar display with a div- and
  ul-based wrapper
- Added a media query so small screens see an event list rather than
  full calendar
- Updated visual styling - events now have a small blue border around
  them, date numbers have small circles around them, the header is
  reversed (white on gray), and days not in the current month are light
  gray
