### PR TITLE
Calendar display fix

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -144,7 +144,7 @@ function sc_draw_calendar( $month, $year ){
 	endfor;
 
 	//finish the rest of the days in the week
-	if( $days_in_this_week < 8 ):
+	if( $days_in_this_week > 1 && $days_in_this_week < 8 ):
 		for( $x = 1; $x <= ( 8 - $days_in_this_week ); $x++ ):
 		  $calendar.= '<td class="calendar-day-np" valign="top"><div class="sc_day_div"></div></td>';
 		endfor;


### PR DESCRIPTION
The calendar code outputs 7 too many 'padding' TDs whenever the last day of a month coincides with the last day of the week. Checking for `$days_in_this_week > 1` (inside the `sc_draw_calendar()`) solves that.